### PR TITLE
Add `jitpack.yml`

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,19 +1,7 @@
-# jitpack.yml for a Gradle project
-jdk:
-  - openjdk21
+# Tell Jitpack to build using Java 21 (defaults to 8)
 before_install:
-  - sdk install java 21.0.4-open
-  - sdk use java 21.0.4-open
-  #- sdk install maven
-  #- mvn -v
-#gradle:
-#  wrapper: true  # Indicates if the project uses Gradle wrapper
-
-#install:
-#  - ./gradle clean build  # Commands for building your project
-
-#build:
-#  - ./gradle assemble  # Commands for assembling the library artifacts
-
-# Optionally, if you have custom dependencies or special needs for submodules
-# submodules: true
+  # Fix: https://github.com/jitpack/jitpack.io/issues/4506#issuecomment-864562270
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 21.0.3-zulu
+  - sdk use java 21.0.3-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,11 @@
 # jitpack.yml for a Gradle project
 jdk:
-  - openjdk17
+  - openjdk21
+before_install:
+  - sdk install java 21.0.4-open
+  - sdk use java 21.0.4-open
+  #- sdk install maven
+  #- mvn -v
 #gradle:
 #  wrapper: true  # Indicates if the project uses Gradle wrapper
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,6 @@
 # jitpack.yml for a Gradle project
-before_install:
-  - sdk install java
-  - sdk use java
-
+jdk:
+  - openjdk17
 #gradle:
 #  wrapper: true  # Indicates if the project uses Gradle wrapper
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,14 +3,14 @@ before_install:
   - sdk install java
   - sdk use java
 
-gradle:
-  wrapper: true  # Indicates if the project uses Gradle wrapper
+#gradle:
+#  wrapper: true  # Indicates if the project uses Gradle wrapper
 
-install:
-  - ./gradle clean build  # Commands for building your project
+#install:
+#  - ./gradle clean build  # Commands for building your project
 
-build:
-  - ./gradle assemble  # Commands for assembling the library artifacts
+#build:
+#  - ./gradle assemble  # Commands for assembling the library artifacts
 
 # Optionally, if you have custom dependencies or special needs for submodules
 # submodules: true


### PR DESCRIPTION
This pull request includes an update to the `jitpack.yml` file to specify the use of Java 21 for building the project, along with some cleanup and improvements.

Changes to build configuration:

* Updated `jitpack.yml` to specify Java 21 for the build process instead of the default Java 8.
* Removed redundant `gradle` and `install` sections, simplifying the configuration.
* Added commands to initialize and update SDKMAN, and to install and use Java 21.0.3-zulu.