### PR TITLE
Add thread pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>games.negative.alumina</groupId>
     <artifactId>alumina</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.2.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/games/negative/alumina/thread/ThreadPool.java
+++ b/src/main/java/games/negative/alumina/thread/ThreadPool.java
@@ -1,0 +1,20 @@
+package games.negative.alumina.thread;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@UtilityClass
+public final class ThreadPool {
+
+    private static final ExecutorService pool = Executors.newCachedThreadPool();
+
+    /**
+     * Get the thread pool
+     * @return The thread pool
+     */
+    public ExecutorService get() {
+        return pool;
+    }
+}


### PR DESCRIPTION
This pull request includes an update to the project version and the addition of a new utility class for thread management.

Version update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the project version from `3.1.1-SNAPSHOT` to `3.2.1-SNAPSHOT`.

New utility class:

* [`src/main/java/games/negative/alumina/thread/ThreadPool.java`](diffhunk://#diff-6bcece37759c4d3cb64c6993763df35fe0bf7ba6466389fe8ca9928083c3dd40R1-R20): Added a new `ThreadPool` utility class with a cached thread pool and a method to retrieve it.