### PR TITLE
add copyright

### DIFF
--- a/src/main/java/games/negative/alumina/thread/ThreadPool.java
+++ b/src/main/java/games/negative/alumina/thread/ThreadPool.java
@@ -1,3 +1,28 @@
+/*
+ *  MIT License
+ *
+ * Copyright (C) 2025 Negative Games
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package games.negative.alumina.thread;
 
 import lombok.experimental.UtilityClass;


### PR DESCRIPTION
This pull request includes a small but important change to the `ThreadPool.java` file. The change adds the MIT license header to the file.

* [`src/main/java/games/negative/alumina/thread/ThreadPool.java`](diffhunk://#diff-6bcece37759c4d3cb64c6993763df35fe0bf7ba6466389fe8ca9928083c3dd40R1-R25): Added the MIT license header to ensure proper licensing and usage rights.