### PR TITLE
add positions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>games.negative.alumina</groupId>
     <artifactId>alumina</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/games/negative/alumina/position/BlockPosition.java
+++ b/src/main/java/games/negative/alumina/position/BlockPosition.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Negative Games
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package games.negative.alumina.position;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This class represents a block position in the world.
+ * @param world the world the block is in
+ * @param x The x-coordinate of the block
+ * @param y The y-coordinate of the block
+ * @param z The z-coordinate of the block
+ */
+public record BlockPosition(World world, int x, int y, int z) {
+
+    /**
+     * Gets the {@link Location} of this block position.
+     * @return The location of this block position
+     */
+    @NotNull
+    public Location location() {
+        return new Location(world, x, y, z);
+    }
+
+    /**
+     * Gets the {@link Block} at this position.
+     * @return The block at this position
+     */
+    @NotNull
+    public Block block() {
+        return world.getBlockAt(x, y, z);
+    }
+
+    /**
+     * Creates a new BlockPosition from a Location.
+     *
+     * @param location The location to create the BlockPosition from
+     * @return A new BlockPosition
+     */
+    public static BlockPosition fromLocation(@NotNull Location location) {
+        World world = location.getWorld();
+        Preconditions.checkState(world != null, "World cannot be null!");
+
+        return new BlockPosition(world, location.getBlockX(), location.getBlockY(), location.getBlockZ());
+    }
+}

--- a/src/main/java/games/negative/alumina/position/Position.java
+++ b/src/main/java/games/negative/alumina/position/Position.java
@@ -51,7 +51,8 @@ public record Position(World world, double x, double y, double z, float yaw, flo
      * @return The block position of this position
      */
     public BlockPosition blockPosition() {
-        return new BlockPosition(world, (int) x, (int) y, (int) z);
+        Location loc = new Location(world, x, y, z);
+        return new BlockPosition(world, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
     }
 
     /**

--- a/src/main/java/games/negative/alumina/position/Position.java
+++ b/src/main/java/games/negative/alumina/position/Position.java
@@ -70,7 +70,7 @@ public record Position(World world, double x, double y, double z, float yaw, flo
      */
     @NotNull
     public Block block() {
-        return world.getBlockAt((int) x, (int) y, (int) z);
+        return world.getBlockAt((int) Math.floor(x), (int) Math.floor(y), (int) Math.floor(z));
     }
 
     /**

--- a/src/main/java/games/negative/alumina/position/Position.java
+++ b/src/main/java/games/negative/alumina/position/Position.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Negative Games
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package games.negative.alumina.position;
+
+import com.google.common.base.Preconditions;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.jetbrains.annotations.CheckReturnValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class represents a position in the world along with the yaw and pitch.
+ * @param world the world the position is in
+ * @param x The x-coordinate of the position
+ * @param y The y-coordinate of the position
+ * @param z The z-coordinate of the position
+ * @param yaw the yaw of the position
+ * @param pitch the pitch of the position
+ */
+public record Position(World world, double x, double y, double z, float yaw, float pitch) {
+
+    /**
+     * Gets the {@link BlockPosition} of this position.
+     * @return The block position of this position
+     */
+    public BlockPosition blockPosition() {
+        return new BlockPosition(world, (int) x, (int) y, (int) z);
+    }
+
+    /**
+     * Gets the {@link Location} of this position.
+     * @return The location of this position
+     */
+    @NotNull
+    public Location location() {
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+
+    /**
+     * Gets the {@link Block} at this position.
+     * @return The block at this position
+     */
+    @NotNull
+    public Block block() {
+        return world.getBlockAt((int) x, (int) y, (int) z);
+    }
+
+    /**
+     * Teleports the given entity to this position.
+     * @param entity The entity to teleport
+     * @return True if the teleport was successful, false otherwise
+     */
+    public boolean teleport(@NotNull Entity entity) {
+        return entity.teleport(location(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+    }
+
+    /**
+     * Teleports the given entity to this position asynchronously.
+     * @param entity The entity to teleport
+     * @return A CompletableFuture that will be completed with true if the teleport was successful, false otherwise
+     */
+    @CheckReturnValue
+    public CompletableFuture<Boolean> teleportAsync(@NotNull Entity entity) {
+        return entity.teleportAsync(location(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+    }
+
+    /**
+     * Creates a new Position from a Location.
+     * @param location The location to create the Position from
+     * @return A new Position
+     */
+    public static Position fromLocation(@NotNull Location location) {
+        World world = location.getWorld();
+        Preconditions.checkState(world != null, "World cannot be null!");
+
+        return new Position(world, location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
+    }
+}


### PR DESCRIPTION
This pull request introduces two new classes, `BlockPosition` and `Position`, to the `games.negative.alumina.position` package. These classes represent positions in the game world and provide various utility methods for interacting with these positions.

New classes and their functionalities:

* `BlockPosition` class:
  * Represents a block position in the world with `world`, `x`, `y`, and `z` coordinates.
  * Provides methods to get the `Location` and `Block` at this position.
  * Includes a static method to create a `BlockPosition` from a `Location`.

* `Position` class:
  * Represents a position in the world with `world`, `x`, `y`, `z` coordinates, and `yaw` and `pitch` for orientation.
  * Provides methods to get the `BlockPosition`, `Location`, and `Block` at this position.
  * Includes methods to teleport an entity to this position, both synchronously and asynchronously.
  * Includes a static method to create a `Position` from a `Location`.