### PR TITLE
fix legacy hex codes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>games.negative.alumina</groupId>
     <artifactId>alumina</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/games/negative/alumina/message/translation/LegacyMiniMessageTranslator.java
+++ b/src/main/java/games/negative/alumina/message/translation/LegacyMiniMessageTranslator.java
@@ -27,6 +27,7 @@ package games.negative.alumina.message.translation;
 
 import com.google.common.collect.Maps;
 import lombok.experimental.UtilityClass;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -75,6 +76,8 @@ public class LegacyMiniMessageTranslator {
         for (Map.Entry<String, String> entry : legacyToMiniMessage.entrySet()) {
             content = content.replaceAll("&" + entry.getKey(), entry.getValue());
         }
+
+        content = content.replaceAll("&#([A-Fa-f0-9]{6})", "<color:#$1>");
 
         return content;
     }


### PR DESCRIPTION
This pull request includes version updates and functionality improvements to the `LegacyMiniMessageTranslator` class. The most significant changes involve updating the project version in `pom.xml` and enhancing the translation logic for legacy color codes.

### Version update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the project version from `3.3.1-SNAPSHOT` to `3.4.1-SNAPSHOT`.

### Functional improvements:

* [`src/main/java/games/negative/alumina/message/translation/LegacyMiniMessageTranslator.java`](diffhunk://#diff-6cd938b247de9746d628832b5b600096509896168033d40f0cb7ce32cbedc5e2R30): Added the `LegacyComponentSerializer` import to prepare for handling legacy text serialization.
* [`src/main/java/games/negative/alumina/message/translation/LegacyMiniMessageTranslator.java`](diffhunk://#diff-6cd938b247de9746d628832b5b600096509896168033d40f0cb7ce32cbedc5e2R80-R81): Enhanced the `legacyToMiniMessage` method to support converting hex color codes (e.g., `&#RRGGBB`) into MiniMessage format (e.g., `<color:#RRGGBB>`).